### PR TITLE
Destruction repro take 2

### DIFF
--- a/Client/Client.cpp
+++ b/Client/Client.cpp
@@ -27,11 +27,10 @@ public :
             return hr;
         }
 
-        RECT rcPos = { CW_USEDEFAULT, 0, CW_USEDEFAULT, 0};
         HMENU hMenu = LoadMenu(_AtlBaseModule.GetResourceInstance(), MAKEINTRESOURCE(IDR_MENU1));
 
         m_window = std::make_unique<ClientWindow>();
-        auto wnd = m_window->Create(GetDesktopWindow(), rcPos, _T("Client"), 0, 0, hMenu);
+        auto wnd = m_window->Create(GetDesktopWindow(), 0, _T("Client"), 0, 0, hMenu);
         if (!IsWindow(wnd))
             return E_FAIL;
         

--- a/Client/ClientWindow.h
+++ b/Client/ClientWindow.h
@@ -4,7 +4,6 @@
 #include "../common/common.h"
 #include "FrameSourceImpl.h"
 #include "Client_i.h"
-
 using namespace ATL;
 class ClientWindow : public CWindowImpl<ClientWindow, ATL::CWindow, ATL::CFrameWinTraits >
 {
@@ -12,6 +11,8 @@ public:
     BEGIN_MSG_MAP(ClientWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)
         MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
+        MESSAGE_HANDLER(WM_LBUTTONUP, OnClosePlayer)
+        MESSAGE_HANDLER(WM_PAINT, OnPaint)
     END_MSG_MAP()
 
     void OnFinalMessage(HWND /*hWnd*/)
@@ -19,10 +20,25 @@ public:
         ::PostQuitMessage(0);
     }
 
+    LRESULT OnPaint(UINT, WPARAM, LPARAM, BOOL&) {
+        PAINTSTRUCT ps = {};
+        auto hdc = BeginPaint(&ps);
+
+        std::wstring text = L"Click in window to stop player. If you hear a beep, unstructured behavior occured";
+        TextOut(hdc, 0, 0, text.data(), static_cast<int>(text.size()));
+
+        EndPaint(&ps);
+        return 0;
+    }
+
+    LRESULT OnClosePlayer(UINT, WPARAM, LPARAM, BOOL&) {
+        m_player = nullptr;
+        return 0;
+    }
+
     LRESULT OnDestroy(UINT, WPARAM, LPARAM, BOOL& bHandled)
     {
-        m_player->Pause();
-        m_player.Release();
+        m_player = nullptr;
         bHandled = FALSE;
         return 0;
     }
@@ -30,17 +46,14 @@ public:
     LRESULT OnCreate(UINT, WPARAM, LPARAM, BOOL& handled)
     {
         try {
-            CLSID clsid = {};
-            CHECK(CLSIDFromString(L"Player", &clsid));
-
             CComPtr<IUnknown> ctrl;
-            CHECK(ctrl.CoCreateInstance(clsid, nullptr, CLSCTX_LOCAL_SERVER)); // allow both in-process and out-of-process "apps"
+            CHECK(ctrl.CoCreateInstance(L"Player", nullptr, CLSCTX_LOCAL_SERVER)); // Create a Player instance in a separate process
             CHECK(ctrl.QueryInterface(&m_player));
 
             m_source = CreateLocalInstance<CFrameSourceImpl>();
             CHECK(m_player->Initialize(m_source));
-            CHECK(m_player->Play());
 
+            CHECK(m_player->Play());
             handled = TRUE;
             return 0;
         }

--- a/Client/FrameSourceImpl.cpp
+++ b/Client/FrameSourceImpl.cpp
@@ -3,14 +3,13 @@
 #include "../common/common.h"
 
 static int s_counter = 0;
-
 Frame::Frame() : m_counter{ s_counter++ } {}
 
 HRESULT Frame::GetId(int * id) {
     if (!id)
         return E_POINTER;
     
-    Sleep(1); // Any work will do to make the server process it's own messages
+    Sleep(100);         // Simulate workload
     *id = m_counter;
     return S_OK;
 }

--- a/Player/Player.h
+++ b/Player/Player.h
@@ -1,48 +1,15 @@
 #pragma once
 #include "resource.h"       // main symbols
-#include <atlctl.h>
-#include <sstream>
 #include "Player_i.h"
-#include <atlbase.h>
 #include "../common/common.h"
 using namespace ATL;
-
-static bool s_created = false;
-
-class PlayerWindow : public ATL::CWindowImpl<PlayerWindow, ATL::CWindow, ATL::CFrameWinTraits> {
-public:
-    DECLARE_WND_CLASS(L"PlayerWindow");
-    BEGIN_MSG_MAP(PlayerWindow)
-        MESSAGE_HANDLER(WM_TIMER, OnTimer)
-        MESSAGE_HANDLER(WM_PAINT, OnPaint)
-        MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
-    END_MSG_MAP()
-
-protected:
-    virtual LRESULT OnTimer(UINT /*nMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/) = 0;
-    virtual LRESULT OnPaint(UINT /*nMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/) = 0;
-    virtual LRESULT OnDestroy(UINT /*nMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/) = 0;
-};
 
 class ATL_NO_VTABLE Player :
     public CComObjectRootEx<CComSingleThreadModel>,
     public CComCoClass<Player, &CLSID_Player>,
-    public IPlayer,
-    public PlayerWindow
+    public IPlayer
 {
 public:
-    Player() {
-        RECT rect = {0, 0, 600, 400};
-        Create(NULL, &rect, L"Player" );
-        ShowWindow(SW_SHOW);
-    }
-    ~Player() {
-        Pause();
-        m_frame = nullptr;
-        m_source = nullptr;
-        DestroyWindow();
-    }
-
     DECLARE_REGISTRY_RESOURCEID(IDR_PLAYERIMPL)
 
     BEGIN_COM_MAP(Player)
@@ -50,9 +17,7 @@ public:
     END_COM_MAP()
 
 public:
-    LRESULT OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled) override;
-    LRESULT OnPaint(UINT /*nMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/) override;
-    LRESULT OnDestroy(UINT /*nMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& /*bHandled*/) override;
+    LRESULT RunUpdateLoop();
 
     DECLARE_PROTECT_FINAL_CONSTRUCT()
     HRESULT FinalConstruct();
@@ -61,11 +26,9 @@ public:
     HRESULT STDMETHODCALLTYPE Play() override;
     HRESULT STDMETHODCALLTYPE Pause() override;
     HRESULT STDMETHODCALLTYPE Initialize(IFrameSource * source) override;
-
 private:
     CComPtr<IFrame> m_frame;
     CComPtr<IFrameSource> m_source;
-    int m_timer = -1;
 };
 
 OBJECT_ENTRY_AUTO(__uuidof(Player), Player)

--- a/Player/Player.vcxproj
+++ b/Player/Player.vcxproj
@@ -276,6 +276,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Player.h" />
+    <ClInclude Include="PlayerModule.h" />
     <ClInclude Include="Player_i.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="stdafx.h" />

--- a/Player/Player.vcxproj.filters
+++ b/Player/Player.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="Player.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PlayerModule.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Player.rc">

--- a/Player/PlayerModule.cpp
+++ b/Player/PlayerModule.cpp
@@ -1,20 +1,13 @@
 #include "stdafx.h"
+#include "PlayerModule.h"
 #include "resource.h"
 #include "Player_i.h"
 #include "../common/common.h"
+#include "Player.h"
+#include <memory>
+
 using namespace ATL;
-class CPlayerModule : public ATL::CAtlExeModuleT< CPlayerModule >
-{
-public :
-	DECLARE_LIBID(LIBID_PlayerLib)
-	DECLARE_REGISTRY_APPID_RESOURCEID(IDR_PLAYER, "{A8FB7E99-B022-49A3-B329-E2DDF3FF64B8}")
-    HRESULT Run(_In_ int nShowCmd = SW_HIDE) throw() {
-        DisableComCatchExceptions();
-        //while (!IsDebuggerPresent())
-        //    Sleep(100);
-        return ATL::CAtlExeModuleT< CPlayerModule >::Run(nShowCmd);
-    }
-};
+
 
 CPlayerModule _AtlModule;
 
@@ -22,4 +15,9 @@ extern "C" int WINAPI _tWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstan
 								LPTSTR /*lpCmdLine*/, int nShowCmd)
 {
 	return _AtlModule.WinMain(nShowCmd);
+}
+
+CPlayerModule * GetModule()
+{
+    return &_AtlModule;
 }

--- a/Player/PlayerModule.h
+++ b/Player/PlayerModule.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <atlwin.h>
+#include "Player.h"
+#include <memory>
+#define WM_UPDATE WM_USER+1
+class Player;
+
+class PlayerWindow : public ATL::CWindowImpl<PlayerWindow, ATL::CWindow, ATL::CFrameWinTraits> {
+public:
+    PlayerWindow() {
+        RECT rect = { 0, 0, 600, 400 };
+        Create(NULL, &rect, L"Player");
+        ShowWindow(SW_SHOW);
+    }
+
+    ~PlayerWindow() {
+        DestroyWindow();
+        m_hWnd = NULL;
+    }
+
+    void SetPlayer(Player * player) {
+        m_player = player;
+        PostMessage(WM_UPDATE);
+    }
+
+    DECLARE_WND_CLASS(L"PlayerWindow");
+    BEGIN_MSG_MAP(PlayerWindow)
+        MESSAGE_HANDLER(WM_UPDATE, OnUpdate)
+    END_MSG_MAP()
+
+private:
+    virtual LRESULT OnUpdate(UINT /*nMsg*/, WPARAM /*wParam*/, LPARAM /*lParam*/, BOOL& bHandled) {
+        if (m_player)
+            m_player->RunUpdateLoop();
+        return 0;
+    }
+
+private:
+    Player * m_player = nullptr;
+};
+
+
+class CPlayerModule : public ATL::CAtlExeModuleT< CPlayerModule >
+{
+public:
+    DECLARE_LIBID(LIBID_PlayerLib)
+    DECLARE_REGISTRY_APPID_RESOURCEID(IDR_PLAYER, "{A8FB7E99-B022-49A3-B329-E2DDF3FF64B8}")
+    HRESULT Run(_In_ int nShowCmd = SW_HIDE) throw() {
+        DisableComCatchExceptions();
+        //while (!IsDebuggerPresent())
+        //    Sleep(100);
+        return ATL::CAtlExeModuleT< CPlayerModule >::Run(nShowCmd);
+    }
+
+    HRESULT PreMessageLoop(_In_ int nShowCmd) throw() {
+        auto result = ATL::CAtlExeModuleT< CPlayerModule >::PreMessageLoop(nShowCmd);
+        m_window = std::make_unique<PlayerWindow>();
+        return result;
+    }
+
+    std::unique_ptr<PlayerWindow> m_window;
+};
+
+CPlayerModule * GetModule();

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See Player.cpp, Player::RunUpdateLoop(), where the player is spinning on m_frame
 * Attach with a debugger to Player.exe, and put a breakpoint in FinalRelease
 * Click in client window.
 * Observe call stack of the Player.exe, where the outgoing call m_frame->GetId() results in a call to the Player's destructor
-
+```
     Player.exe!Player::FinalRelease() Line 29   C++
     Player.exe!ATL::CComObject<Player>::~CComObject<Player>() Line 2915 C++
     Player.exe!ATL::CComObject<Player>::`scalar deleting destructor'(unsigned int)  C++
@@ -77,7 +77,7 @@ See Player.cpp, Player::RunUpdateLoop(), where the player is spinning on m_frame
     Player.exe!wWinMainCRTStartup() Line 17 C++
     kernel32.dll!BaseThreadInitThunk() Unknown
     ntdll.dll!RtlUserThreadStart() Unknown
-
+```
 
 ## References
 [DCOM in Vista specifically processing WM_PAINT messages](https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/5a28a9f5-5711-4efa-843e-e98927fa2b92/dcom-in-vista-specifically-processing-wmpaint-messages?forum=windowsgeneraldevelopmentissues)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ See Player.cpp, Player::RunUpdateLoop(), where the player is spinning on m_frame
 * Two windows should appear, Player and Client. 
 * Attach with a debugger to Player.exe, and put a breakpoint in FinalRelease
 * Click in client window.
-* Observe call stack of the Player.exe, where the outgoing call m_frame->GetId() results in a call to the Player's destructor
+* Observe call stack of the Player.exe, where the outgoing call m_frame->GetId() from Player::RunUpdateLoop() results in a call to the Player's destructor
 ```
     Player.exe!Player::FinalRelease() Line 29   C++
     Player.exe!ATL::CComObject<Player>::~CComObject<Player>() Line 2915 C++
     Player.exe!ATL::CComObject<Player>::`scalar deleting destructor'(unsigned int)  C++
-    Player.exe!ATL::CComObject<Player>::Release() Line 2934 C++
+--->Player.exe!ATL::CComObject<Player>::Release() Line 2934 C++
     ole32.dll!CStdIdentity::ReleaseCtrlUnk() Line 1149  C++
     ole32.dll!CStdMarshal::Disconnect(unsigned long dwType) Line 3608   C++
     ole32.dll!CStdMarshal::HandlePendingDisconnect(HRESULT hr)  C++
@@ -60,7 +60,7 @@ See Player.cpp, Player::RunUpdateLoop(), where the player is spinning on m_frame
     rpcrt4.dll!NdrpClientCall2(struct _MIDL_STUB_DESC const *,unsigned char const *,unsigned char *)    Unknown
     ole32.dll!ObjectStublessClient(void * ParamAddress, __int64 * FloatRegisters, long Method) Line 620 C++
     ole32.dll!ObjectStubless() Line 117 Unknown
-    Player.exe!Player::RunUpdateLoop() Line 16  C++
+--->Player.exe!Player::RunUpdateLoop() Line 16  C++
     Player.exe!PlayerWindow::OnUpdate(unsigned int __formal, unsigned __int64 __formal, __int64 __formal, int & bHandled) Line 35   C++
     Player.exe!PlayerWindow::ProcessWindowMessage(HWND__ * hWnd, unsigned int uMsg, unsigned __int64 wParam, __int64 lParam, __int64 & lResult, unsigned long dwMsgMapID) Line 28   C++
     Player.exe!ATL::CWindowImplBaseT<ATL::CWindow,ATL::CWinTraits<114229248,262400> >::WindowProc(HWND__ * hWnd, unsigned int uMsg, unsigned __int64 wParam, __int64 lParam) Line 3526  C++

--- a/README.md
+++ b/README.md
@@ -5,31 +5,79 @@ Sample code to demonstrate unstructured behavior when running a local COM server
 While a local single threaded COM server is doing an outgoing call to a single threaded client, it appears to be able to process it's own message queue. The server state may therefore have changed when the outgoing call returns. 
 
 ## Description
-This sample code implements a client application, and a local COM server called 'Player'. The client creates a Player object, and provides the player with a frame data source. The player displays the frame numbers it got from the client. 
+This sample code implements a client application, and a local COM server called 'Player'. The client creates a Player object, and provides the player with a frame data source. Once started, the player continuously queries the client for frame information. The player's main thread is therefore busy all the time.
 
-The player is driven by a timer that triggers fetching of frame data from the client. Once a frame is received, it schedules a redraw by invalidating it's own window. On the resulting paint messages, the player then prints the frame number it got from the client. If, however, the client spends some time processing the frame request, the player appears to be able to process it's own message queue (including painting to sreen while it is fetching the frame from the client). In this case, the player prints a message telling that it did not receive a frame.
+When left clicking in the client window, the client releases it's reference to the player object. Even if the Player's main thread is busy calling back into the client, the release is processed, destroying the Player object. However, since the player at this time is busy calling into the client process, the Player crashes when the function call into the client returns. 
 
-Since the player is single threaded, it is surprising that it is able to process it's own message queue while it is, at the same time, calling a function on the client. As a result, the player appears to run two threads, but since it is single threaded, regular synchronization primitives (mutexes) can not be used to protect data.
+Since the player is single threaded, it is surprising that it is able to run it's own destructors while it is, at the same time, calling a function on the client. As a result, the player appears to run two threads, but since it is single threaded, regular synchronization primitives (mutexes) can not be used to protect data.
 
 ## Interesting code snippets:
-See Player/Player.cpp, functions Player::OnPaint and Player::OnTimer, that are annotated with this interesting behavior. 
-
-## Bonus chatter: Server destruction
-Server destruction is a special case, that cause particularly visible effects (not illustrated in this sample)
-
-1. The server calls a function on the client
-2. The client is busy, and can not immediately handle the request, so the server has to wait.
-3. Now the client starts processing it's own messages
-4. The client releases the server
-5. The server destructors run
-6. The client services the call from the client (step 1.)
-7. The function call in 1. returns, but the server is now destroyed, and the stack is gone. 
+See Player.cpp, Player::RunUpdateLoop(), where the player is spinning on m_frame->GetId(). 
 
 ## Build/run instructions
 
 * Build projects Client and Player. Player.exe is registered automatically in a post build event.
 * Run Client.exe
-* Two windows should appear, Player and Client. The Player window should show some continuously updating text. 
+* Two windows should appear, Player and Client. 
+* Attach with a debugger to Player.exe, and put a breakpoint in FinalRelease
+* Click in client window.
+* Observe call stack of the Player.exe, where the outgoing call m_frame->GetId() results in a call to the Player's destructor
+
+    Player.exe!Player::FinalRelease() Line 29   C++
+    Player.exe!ATL::CComObject<Player>::~CComObject<Player>() Line 2915 C++
+    Player.exe!ATL::CComObject<Player>::`scalar deleting destructor'(unsigned int)  C++
+    Player.exe!ATL::CComObject<Player>::Release() Line 2934 C++
+    ole32.dll!CStdIdentity::ReleaseCtrlUnk() Line 1149  C++
+    ole32.dll!CStdMarshal::Disconnect(unsigned long dwType) Line 3608   C++
+    ole32.dll!CStdMarshal::HandlePendingDisconnect(HRESULT hr)  C++
+    ole32.dll!CRemoteUnknown::RemReleaseWorker(unsigned short cInterfaceRefs, tagREMINTERFACEREF * InterfaceRefs, int fTopLevel) Line 1078  C++
+    rpcrt4.dll!Invoke()    Unknown
+    rpcrt4.dll!Ndr64StubWorker(void *,void *,struct _RPC_MESSAGE *,struct _MIDL_SERVER_INFO_ *,long (*const *)(void),struct _MIDL_SYNTAX_INFO *,unsigned long *)    Unknown
+    rpcrt4.dll!NdrStubCall3()  Unknown
+    ole32.dll!CStdStubBuffer_Invoke(IRpcStubBuffer * This, tagRPCOLEMESSAGE * prpcmsg, IRpcChannelBuffer * pRpcChannelBuffer) Line 1586 C++
+    ole32.dll!SyncStubInvoke(tagRPCOLEMESSAGE * pMsg, const _GUID & riid, CIDObject * pID, void * pVtableAddress, IRpcChannelBuffer * pChnl, IRpcStubBuffer * pStub, unsigned long * pdwFault) Line 1187    C++
+    ole32.dll!StubInvoke(tagRPCOLEMESSAGE * pMsg, CStdIdentity * pStdID, IRpcStubBuffer * pStub, IRpcChannelBuffer * pChnl, tagIPIDEntry * pIPIDEntry, unsigned long * pdwFault) Line 1396  C++
+    ole32.dll!CCtxComChnl::ContextInvoke(tagRPCOLEMESSAGE * pMessage, IRpcStubBuffer * pStub, tagIPIDEntry * pIPIDEntry, unsigned long * pdwFault) Line 1263    C++
+    ole32.dll!MTAInvoke(tagRPCOLEMESSAGE * pMsg, unsigned long CallCatIn, IRpcStubBuffer * pStub, IInternalChannelBuffer * pChnl, tagIPIDEntry * pIPIDEntry, unsigned long * pdwFault) Line 2105    C++
+    ole32.dll!STAInvoke(tagRPCOLEMESSAGE * pMsg, unsigned long CallCatIn, IRpcStubBuffer * pStub, IInternalChannelBuffer * pChnl, void * pv, tagIPIDEntry * pIPIDEntry, unsigned long * pdwFault) Line 1924 C++
+    ole32.dll!AppInvoke(CMessageCall * pCall, CRpcChannelBuffer * pChannel, IRpcStubBuffer * pStub, void * pv, void * pStubBuffer, tagIPIDEntry * pIPIDEntry, LocalThis * pLocalb) Line 1081    C++
+    ole32.dll!ComInvokeWithLockAndIPID(CMessageCall * pCall, tagIPIDEntry * pIPIDEntry) Line 1727   C++
+    ole32.dll!ComInvoke(CMessageCall * pCall) Line 1469 C++
+    ole32.dll!ThreadDispatch(void * param) Line 298 C++
+    ole32.dll!ThreadWndProc(HWND__ * window, unsigned int message, unsigned __int64 wparam, __int64 params) Line 654    C++
+    user32.dll!UserCallWinProcCheckWow()   Unknown
+    user32.dll!DispatchMessageWorker() Unknown
+    ole32.dll!CCliModalLoop::PeekRPCAndDDEMessage() Line 1508   C++
+    ole32.dll!CCliModalLoop::BlockFn(void * * ahEvent, unsigned long cEvents, unsigned long * lpdwSignaled) C++
+    ole32.dll!ModalLoop(CMessageCall * pcall) Line 211  C++
+    ole32.dll!ThreadSendReceive(CMessageCall * pCall) Line 4938 C++
+    ole32.dll!CRpcChannelBuffer::SwitchAptAndDispatchCall(CMessageCall * * ppCall) Line 4454    C++
+    ole32.dll!CRpcChannelBuffer::SendReceive2(tagRPCOLEMESSAGE * pMessage, unsigned long * pstatus) Line 4074   C++
+    ole32.dll!CCliModalLoop::SendReceive(tagRPCOLEMESSAGE * pMsg, unsigned long * pulStatus, IInternalChannelBuffer * pChnl) Line 899   C++
+    ole32.dll!CAptRpcChnl::SendReceive(tagRPCOLEMESSAGE * pMsg, unsigned long * pulStatus) Line 583 C++
+    ole32.dll!CCtxComChnl::SendReceive(tagRPCOLEMESSAGE * pMessage, unsigned long * pulStatus) Line 734 C++
+    ole32.dll!NdrExtpProxySendReceive(void * pThis, _MIDL_STUB_MESSAGE * pStubMsg) Line 1932    C++
+    rpcrt4.dll!NdrpClientCall2(struct _MIDL_STUB_DESC const *,unsigned char const *,unsigned char *)    Unknown
+    ole32.dll!ObjectStublessClient(void * ParamAddress, __int64 * FloatRegisters, long Method) Line 620 C++
+    ole32.dll!ObjectStubless() Line 117 Unknown
+    Player.exe!Player::RunUpdateLoop() Line 16  C++
+    Player.exe!PlayerWindow::OnUpdate(unsigned int __formal, unsigned __int64 __formal, __int64 __formal, int & bHandled) Line 35   C++
+    Player.exe!PlayerWindow::ProcessWindowMessage(HWND__ * hWnd, unsigned int uMsg, unsigned __int64 wParam, __int64 lParam, __int64 & lResult, unsigned long dwMsgMapID) Line 28   C++
+    Player.exe!ATL::CWindowImplBaseT<ATL::CWindow,ATL::CWinTraits<114229248,262400> >::WindowProc(HWND__ * hWnd, unsigned int uMsg, unsigned __int64 wParam, __int64 lParam) Line 3526  C++
+    user32.dll!UserCallWinProcCheckWow()   Unknown
+    user32.dll!DispatchMessageWorker() Unknown
+    Player.exe!ATL::CAtlExeModuleT<CPlayerModule>::RunMessageLoop() Line 3698   C++
+    Player.exe!ATL::CAtlExeModuleT<CPlayerModule>::Run(int nShowCmd) Line 3715  C++
+    Player.exe!CPlayerModule::Run(int nShowCmd) Line 53 C++
+    Player.exe!ATL::CAtlExeModuleT<CPlayerModule>::WinMain(int nShowCmd) Line 3537  C++
+    Player.exe!wWinMain(HINSTANCE__ * __formal, HINSTANCE__ * __formal, wchar_t * __formal, int nShowCmd) Line 18   C++
+    Player.exe!invoke_main() Line 118   C++
+    Player.exe!__scrt_common_main_seh() Line 253    C++
+    Player.exe!__scrt_common_main() Line 296    C++
+    Player.exe!wWinMainCRTStartup() Line 17 C++
+    kernel32.dll!BaseThreadInitThunk() Unknown
+    ntdll.dll!RtlUserThreadStart() Unknown
+
 
 ## References
 [DCOM in Vista specifically processing WM_PAINT messages](https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/5a28a9f5-5711-4efa-843e-e98927fa2b92/dcom-in-vista-specifically-processing-wmpaint-messages?forum=windowsgeneraldevelopmentissues)

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ Server destruction is a special case, that cause particularly visible effects (n
 * Build projects Client and Player. Player.exe is registered automatically in a post build event.
 * Run Client.exe
 * Two windows should appear, Player and Client. The Player window should show some continuously updating text. 
+
+## References
+[DCOM in Vista specifically processing WM_PAINT messages](https://social.msdn.microsoft.com/Forums/windowsdesktop/en-US/5a28a9f5-5711-4efa-843e-e98927fa2b92/dcom-in-vista-specifically-processing-wmpaint-messages?forum=windowsgeneraldevelopmentissues)


### PR DESCRIPTION
Avoid timers, OnPaint, and InvalidateRect in reproducer.

This version shows unstructured behavior on app destruction.
1. The client starts an out of process COM server called Player.
2. The Player starts running a loop, continuously querying he client for a frame Id.
3. When clicking in client window, the client releases it's reference to the player.
4. The player is destructed, even if the player is in an outgoing call to the client. When the call returns to the player, the object is destructed and crashes.